### PR TITLE
Add option to exclude breakpoints from generation process and add mq default conditon.

### DIFF
--- a/scss/_generator.scss
+++ b/scss/_generator.scss
@@ -4,8 +4,7 @@
 @import 'helpers/breakpoints-map-transformer';
 
 @mixin generator($config) {
-    $breakpoints: excludeBreakpoints(map-get($svala-options, 'breakpoints'));
-    $breakpoints: addConditionToValues($breakpoints);
+    $breakpoints: transformBreakpoints(map-get($svala-options, 'breakpoints'));
     $breakpoint-modifier-divider: map-get($svala-options, 'breakpoint-modifier-divider');
 
     // Set up a few guards with errors and warnings

--- a/scss/_generator.scss
+++ b/scss/_generator.scss
@@ -1,9 +1,11 @@
 @import 'config/default-options';
 @import 'config/default-helpers';
 @import 'tools/map-iterator';
+@import 'helpers/breakpoints-map-transformer';
 
 @mixin generator($config) {
-    $breakpoints: map-get($svala-options, 'breakpoints');
+    $breakpoints: excludeBreakpoints(map-get($svala-options, 'breakpoints'));
+    $breakpoints: addConditionToValues($breakpoints);
     $breakpoint-modifier-divider: map-get($svala-options, 'breakpoint-modifier-divider');
 
     // Set up a few guards with errors and warnings

--- a/scss/config/_default-options.scss
+++ b/scss/config/_default-options.scss
@@ -1,5 +1,7 @@
 $svala-default-options: (
     'breakpoints': null,
+    'exclude-breakpoints': (),
+    'condition': 'min-width',
     'prefix': 'u',
     'prefix-divider': '-',
     'postfix': '',

--- a/scss/helpers/_breakpoints-map-transformer.scss
+++ b/scss/helpers/_breakpoints-map-transformer.scss
@@ -1,0 +1,26 @@
+@function addConditionToValues($breakpoints) {
+    $condition: map-get($svala-options, 'condition');
+    $new-breakpoints: ();
+
+    @each $breakpoint, $value in $breakpoints {
+        $map: ($breakpoint: "min-width:" + $value);
+        $new-breakpoints: map-merge($new-breakpoints, $map);
+    }
+
+    @return $new-breakpoints;
+}
+
+@function excludeBreakpoints($breakpoints) {
+    $excluded-breakpoints: map-get($svala-options, 'exclude-breakpoints');
+    $new-breakpoints: ();
+
+    @each $breakpoint, $value in $breakpoints {
+        // merge $breakpoint nur, wenn er nicht in $svala-exclude-breakpoints enthalten ist
+        @if not (index($excluded-breakpoints, $breakpoint)) {
+            $map: ($breakpoint: $value);
+            $new-breakpoints: map-merge($new-breakpoints, $map);
+        }
+    }
+
+    @return $new-breakpoints;
+}

--- a/scss/helpers/_breakpoints-map-transformer.scss
+++ b/scss/helpers/_breakpoints-map-transformer.scss
@@ -15,7 +15,6 @@
     $new-breakpoints: ();
 
     @each $breakpoint, $value in $breakpoints {
-        // merge $breakpoint nur, wenn er nicht in $svala-exclude-breakpoints enthalten ist
         @if not (index($excluded-breakpoints, $breakpoint)) {
             $map: ($breakpoint: $value);
             $new-breakpoints: map-merge($new-breakpoints, $map);
@@ -23,4 +22,8 @@
     }
 
     @return $new-breakpoints;
+}
+
+@function transformBreakpoints($breakpoints) {
+    @return addConditionToValues(excludeBreakpoints($breakpoints));
 }


### PR DESCRIPTION
In at least two projects I had to exclude breakpoints from generation. 
The logic of adding mq condition to the breakpoint values is now done by the generator, so you don't have to do it on project level. I wasn't sure if this was intended from the start because of performance reasons.

This will be a breaking change for now, but could be avoided I think.